### PR TITLE
Add metadata for the galaxy role 

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: Companies House
+  description: Allows Prometheus to export Kafka metrics
+  license: MIT
+
+  min_ansible_version: 2.9.10
+
+  github_branch: kafka-3.1.0
+
+  platforms:
+    - name: Amazon
+      versions:
+        - all
+
+  galaxy_tags:
+      - kafka-prometheus-exporter
+
+dependencies: []


### PR DESCRIPTION
Adds the missing metadata/main.yml file required for building the AMI

